### PR TITLE
Notes on issuer trust list and supported trust frameworks

### DIFF
--- a/ewc-rfc001-issue-verifiable-credential.md
+++ b/ewc-rfc001-issue-verifiable-credential.md
@@ -401,6 +401,7 @@ Once the well-known endpoint for **authorisation server** configuration is resol
   ]
 }
 ```
+Currently, we retain the trust framework specified by EBSI. Subsequently, we will specify an additional RFC defining the EWC trusted issuer list. 
 
 ## 3.5 Authorisation request
 

--- a/ewc-rfc001-issue-verifiable-credential.md
+++ b/ewc-rfc001-issue-verifiable-credential.md
@@ -392,7 +392,8 @@ Once the well-known endpoint for **authorisation server** configuration is resol
     "did:ebsi:v1"
   ],
   "subject_trust_frameworks_supported": [
-    "ebsi"
+    "ebsi",
+    "ewc-issuer-trust-list"
   ],
   "id_token_types_supported": [
     "subject_signed_id_token",


### PR DESCRIPTION
Added the following:

1. ewc issuer trust list to the .well-known configuration 
2. added a note regarding the supported trust framework 
