### PR TITLE
Value issue fixed. vct changed to type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.bak

--- a/ewc-rfc001-issue-verifiable-credential.md
+++ b/ewc-rfc001-issue-verifiable-credential.md
@@ -251,7 +251,7 @@ Once the well-known endpoint for **issuer server** configuration is resolved, th
         }
       ],
       "credential_definition": {
-        "vct": "VerifiablePortableDocumentA1",
+        "type": "VerifiablePortableDocumentA1",
         "claims": {
           "given_name": {
             "display": [
@@ -712,7 +712,7 @@ Authorization: Bearer eyJ0eXAi...KTjcrDMg
 {
    "format": "vc+sd-jwt",
    "credential_definition": {
-      "vct": "VerifiablePortableDocumentA1"
+      "type": "VerifiablePortableDocumentA1"
    },
    "proof": {
       "proof_type": "jwt",


### PR DESCRIPTION
There was an issue with the issuer metadata. In the RFC001 we used two time the key name"vct" for the verifiable credential type which does not exist in the OIDC4CI standard. The correct key name is "type". I changed it. 