### PR TITLE
chore: add W3C JWT credential format

### DIFF
--- a/ewc-supported-formats.csv
+++ b/ewc-supported-formats.csv
@@ -1,7 +1,9 @@
 Name,Type
 JSON Web Token - Verifiable Credential,jwt_vc
 JSON Web Token - Verifiable Presentation,jwt_vp
-Linked data platform - Verifiable Credential,ldp_vc
+W3C JWT - Verifiable Credential,jwt_vc_json
+W3C JWT - Verifiable Presentation,jwt_vc_json
+Linked data proof - Verifiable Credential,ldp_vc
 Selective Disclosure - JSON Web Token,sd-jwt
 Selective Disclosure - JSON Web Token Verifiable Credential,vc+sd-jwt
 Selective Disclosure - JSON Web Token Verifiable Presentation,vp+sd-jwt

--- a/ewc-supported-formats.csv
+++ b/ewc-supported-formats.csv
@@ -2,7 +2,7 @@ Name,Type
 JSON Web Token - Verifiable Credential,jwt_vc
 JSON Web Token - Verifiable Presentation,jwt_vp
 W3C JWT - Verifiable Credential,jwt_vc_json
-W3C JWT - Verifiable Presentation,jwt_vc_json
+W3C JWT - Verifiable Presentation,jwt_vp_json
 Linked data proof - Verifiable Credential,ldp_vc
 Selective Disclosure - JSON Web Token,sd-jwt
 Selective Disclosure - JSON Web Token Verifiable Credential,vc+sd-jwt


### PR DESCRIPTION
- Add W3C Verifiable Credential and Presentation format to align to OPENID4VCI specs: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-vc-signed-as-a-jwt-not-usin
- Fix typo