### PR TITLE
Fix #146: RFC / OIDC4VP / sd-jwt discrepancy

### DIFF
--- a/ewc-rfc001-issue-verifiable-credential.md
+++ b/ewc-rfc001-issue-verifiable-credential.md
@@ -239,7 +239,7 @@ Once the well-known endpoint for **issuer server** configuration is resolved, th
   ],
   "credential_configurations_supported": {
     "VerifiablePortableDocumentA1": {
-      "format": "vc+sd-jwt",
+      "format": "dc+sd-jwt",
       "scope": "VerifiablePortableDocumentA1",
       "cryptographic_binding_methods_supported": [
         "jwk"
@@ -288,7 +288,7 @@ Once the well-known endpoint for **issuer server** configuration is resolved, th
 ```
 
 > [!NOTE]
-> The `credential_configurations_supported` field and it's values change based on the supported credential formats 1) `mso_mdoc` 2) `jwt_vc_json` 3) `vc+sd-jwt`
+> The `credential_configurations_supported` field and it's values change based on the supported credential formats 1) `mso_mdoc` 2) `jwt_vc_json` 3) `dc+sd-jwt`
 > It is important to consult the relevant documentation for each format to ensure that all required fields and values are correctly configured.
 > The supported credential format identifiers in the context of EWC LSPs, can be found [here](https://github.com/EWC-consortium/eudi-wallet-rfcs/blob/main/ewc-supported-formats.csv).
 
@@ -398,7 +398,7 @@ The query params for the authorisation request with `authorization_details` are 
   [
       {
           "type": "openid_credential",
-          "format": "vc+sd-jwt",
+          "format": "dc+sd-jwt",
           "vct": "VerifiablePortableDocumentA1"
       }
   ]
@@ -721,7 +721,7 @@ Authorization: Bearer eyJ0eXAi...KTjcrDMg
 > [!NOTE]
 > In the above, the credentialSubject is optional and is not considered within the scope of EWC LSP. 
 
-**For IETF SD-JWT VC with credential format identifier** `vc+sd-jwt`:
+**For IETF SD-JWT VC with credential format identifier** `dc+sd-jwt`:
 
 
 ```http
@@ -730,7 +730,7 @@ Content-Type: application/json
 Authorization: Bearer eyJ0eXAi...KTjcrDMg
 
 {
-   "format": "vc+sd-jwt",
+   "format": "dc+sd-jwt",
    "vct": "SD_JWT_VC_example_in_OpenID4VCI",
    "proof": {
       "proof_type": "jwt",

--- a/ewc-rfc003-issue-person-identification-data.md
+++ b/ewc-rfc003-issue-person-identification-data.md
@@ -164,7 +164,7 @@ On resolving the `credential_offer_uri` query parameter, the issuer responds wit
 }
 ```
 
-The wallet instance retrieves this JSON response and processes it accordingly. The format of the credential (e.g., jwt_vc, vc+sd-jwt) is specified, focusing on the PID. This process ensures that the credential issuance aligns with the stringent requirements for PID within the EWC ecosystem.
+The wallet instance retrieves this JSON response and processes it accordingly. The format of the credential (e.g., jwt_vc, dc+sd-jwt) is specified, focusing on the PID. This process ensures that the credential issuance aligns with the stringent requirements for PID within the EWC ecosystem.
 
 For the pre-authorized flow, the credential response format is adapted to include the necessary grants for PID issuance:
 
@@ -470,7 +470,7 @@ Content-Type: application/json
 Authorization: Bearer eyJ0eXAi...KTjcrDMg
 
 {
-   "format": "vc+sd-jwt",
+   "format": "dc+sd-jwt",
    "vct": "urn:eu.europa.ec.eudi:pid:1",
    "proof": {
       "proof_type": "jwt",
@@ -492,7 +492,7 @@ In cases where the PID credential is immediately available, the response is stru
 
 ```json
 {
-  "format": "vc+sd-jwt",
+  "format": "dc+sd-jwt",
   "credential": "eyJ0eXAiOi...F0YluuK2Cog", //EncodedPIDCredential
   "c_nonce": "fGFF7UkhLa", //NonceForThisCredential
   "c_nonce_expires_in": 86400
@@ -755,7 +755,7 @@ This is an example of a PID formatted according to Reference implementation (Nov
 
 ```json
 {
-  "format": "vc+sd-jwt",
+  "format": "dc+sd-jwt",
   "credential": "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJfc2QiOlsiNF9QeEs3blhUY2FqYWFUWXRuVXlUVVpjTmZaX2xwLTZuX2xYeFNHa3lFSSIsIjl0ekNvNXNrN2JhN0NkZUN2akdySnlCbjhKZHY0UjJMQzhWRndPUm5ja0UiLCJBVHY0VkNzZDlSTzVxWEFFX0VLMXgwTmtjR1FBT05JSWI1OGtWRG82SU1VIiwiR....2OVloMlNrVXZnaXpqWXRydHBnNl9xRW1xdW9UYyIsIjZRdFNWV0ZWR2ZEQmhfWW14UjJYcVZYNzZmV1IxYnNiX2xWSVNNeWNQYlUiLCJXaEprR3NKcGRiVDYyM2hTR3lLVXVHM0hlMzFIbFFJY2JEdXZiZU9IendRIiwiWmVLRFo4b3NsSHZ0S3NKWDNOY2wwTHNxQlkxVkxnd2xZSGtlSTdhMExkRSIsImtnQlVrWU9ObDgydUl1MG5DRzJDaUo5bmZnZF9aZkJPd0NkMWlxUkpUblUiXX1d~", //EncodedPIDCredential
   "c_nonce": "fGFF7UkhLa", //NonceForThisCredential
   "c_nonce_expires_in": 86400

--- a/ewc-rfc005-issue-legal-person-identification-data.md
+++ b/ewc-rfc005-issue-legal-person-identification-data.md
@@ -273,7 +273,7 @@ Upon resolving the well-known endpoints, the **identity provider** responds with
   ],
   "credentials_supported": {
     "PersonIdentificationData": {
-      "format": "vc+sd-jwt",
+      "format": "dc+sd-jwt",
       "scope": "PersonIdentificationData",
       "cryptographic_binding_methods_supported": [
         "jwk"
@@ -413,7 +413,7 @@ On resolving the `credential_offer_uri` query parameter, the issuer responds wit
 }
 ```
 
-The holder's wallet retrieves this JSON response and processes it accordingly. The format of the credential (e.g., jwt_vc, vc+sd-jwt) is specified, focusing on the LPID. This process ensures that the credential issuance aligns with the stringent requirements for LPID within the EWC ecosystem.
+The holder's wallet retrieves this JSON response and processes it accordingly. The format of the credential (e.g., jwt_vc, dc+sd-jwt) is specified, focusing on the LPID. This process ensures that the credential issuance aligns with the stringent requirements for LPID within the EWC ecosystem.
 
 For the pre-authorized flow, the credential response format is adapted to include the necessary grants for LPID issuance:
 
@@ -422,7 +422,7 @@ For the pre-authorized flow, the credential response format is adapted to includ
   "credential_issuer": "https://identity-provider.gov",
   "credentials": [
     {
-      "format": "vc+sd-jwt",
+      "format": "dc+sd-jwt",
       "types": [
         "VerifiableCredential",
         "PersonIdentificationData"
@@ -726,7 +726,7 @@ Content-Type: application/json
 Authorization: Bearer eyJ0eXAi...KTjcrDMg
 
 {
-   "format": "vc+sd-jwt",
+   "format": "dc+sd-jwt",
    "credential_definition": {
       "vct": "PersonIdentificationData"
    },
@@ -749,7 +749,7 @@ In cases where the LPID credential is immediately available, the response is str
 
 ```json
 {
-  "format": "vc+sd-jwt",
+  "format": "dc+sd-jwt",
   "credential": "eyJ0eXAiOi...F0YluuK2Cog", //EncodedLPIDCredential
   "c_nonce": "fGFF7UkhLa", //NonceForThisCredential
   "c_nonce_expires_in": 86400
@@ -1058,7 +1058,7 @@ The credential can be issued, either directly into the organization's wallet or 
 {
   "credential_configurations_supported": {
     "EWC_LPID_Attestation": {
-      "format": "vc+sd-jwt",
+      "format": "dc+sd-jwt",
       "vct": "EWC_LPID_Attestation",
       "claims": {
         "legal_person_id": {

--- a/ewc-rfc100-interoperability-profile-towards-itb-v1.0.md
+++ b/ewc-rfc100-interoperability-profile-towards-itb-v1.0.md
@@ -289,7 +289,7 @@ must support the following RFCs :
 2. [EWC RFC002: Present Verifiable Credentials - v2.0](https://github.com/EWC-consortium/eudi-wallet-rfcs/blob/main/ewc-rfc002-present-verifiable-credentials.md)
 
 Furthermore, for EWC Phase 2.0 piloting support for:
-1. [Selective Disclosure - JSON Web Token Verifiable Credential	vc+sd-jwt](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc-01)
+1. [Selective Disclosure - JSON Web Token Verifiable Credential	dc+sd-jwt](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc-01)
 2. [Selective Disclosure - JSON Web Token Verifiable Presentation	vp+sd-jwt](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc-01)
 
 is mandatory. 

--- a/ewc-supported-cryptographic-suites.csv
+++ b/ewc-supported-cryptographic-suites.csv
@@ -1,0 +1,2 @@
+Algorithm,Curve (crv),Cryptographic Family,JWT Header Representation
+ES256,P-256,EC,"""alg"": ""ES256"", ""crv"": ""P-256"""

--- a/ewc-supported-formats.csv
+++ b/ewc-supported-formats.csv
@@ -2,4 +2,4 @@ Name,Format Identifier
 W3C JWT - Verifiable Credential,jwt_vc_json
 W3C JWT - Verifiable Presentation,jwt_vp_json
 Selective Disclosure - JSON Web Token Verifiable Credential,vc+sd-jwt
-Selective Disclosure - JSON Web Token Verifiable Presentation,vp+sd-jwt
+Selective Disclosure - JSON Web Token Verifiable Credential,dc+sd-jwt

--- a/payment-rfcs/ewc-rfc008-payment-data-confirmation.md
+++ b/payment-rfcs/ewc-rfc008-payment-data-confirmation.md
@@ -232,7 +232,12 @@ The id of the input descriptor requesting the PWA, here `7c94e62d-82c2-41d7-a649
   "id": "8dd03977-74e4-4b10-ad6d-05a681f44fc9",
   "format": {
     "dc+sd-jwt": {
-      "alg": ["ES256"]
+      "sd-jwt_alg_values": [
+        "ES256"
+      ],
+      "kb-jwt_alg_values": [
+        "ES256"
+      ]
     }
   },
   "input_descriptors": [

--- a/payment-rfcs/ewc-rfc008-payment-data-confirmation.md
+++ b/payment-rfcs/ewc-rfc008-payment-data-confirmation.md
@@ -231,15 +231,8 @@ The id of the input descriptor requesting the PWA, here `7c94e62d-82c2-41d7-a649
 {
   "id": "8dd03977-74e4-4b10-ad6d-05a681f44fc9",
   "format": {
-    "vc+sd-jwt": {
-      "alg": [
-        "ES256"
-      ]
-    },
-    "vp+sd-jwt": {
-      "alg": [
-        "ES256"
-      ]
+    "dc+sd-jwt": {
+      "alg": ["ES256"]
     }
   },
   "input_descriptors": [


### PR DESCRIPTION
Note: All examples have been updated to use `dc+sd-jwt` in accordance with OpenID4VP (ID3). Additionally, the supported credential formats CSV will include both `dc+sd-jwt` and `vc+sd-jwt`, reflecting the transitional period outlined in the IETF SD-JWT VC specification.