### PR TITLE
Fix/143 specifying supported algorithms

### DIFF
--- a/ewc-supported-cryptographic-suites.csv
+++ b/ewc-supported-cryptographic-suites.csv
@@ -1,0 +1,2 @@
+Algorithm,Curve (crv),Cryptographic Family,JWT Header Representation
+ES256,P-256,EC,"""alg"": ""ES256"", ""crv"": ""P-256"""

--- a/payment-rfcs/ewc-rfc008-payment-data-confirmation.md
+++ b/payment-rfcs/ewc-rfc008-payment-data-confirmation.md
@@ -232,7 +232,12 @@ The id of the input descriptor requesting the PWA, here `7c94e62d-82c2-41d7-a649
   "id": "8dd03977-74e4-4b10-ad6d-05a681f44fc9",
   "format": {
     "dc+sd-jwt": {
-      "alg": ["ES256"]
+      "sd-jwt_alg_values": [
+        "ES256"
+      ],
+      "kb-jwt_alg_values": [
+        "ES256"
+      ]
     }
   },
   "input_descriptors": [


### PR DESCRIPTION
### Description
This PR addresses [issue #143](https://github.com/EWC-consortium/eudi-wallet-rfcs/issues/143) by clarifying the allowed cryptographic algorithms in EWC RFCs to ensure interoperability.

### Changes Introduced

- Specifies the permitted algorithm values in accordance with RFC7518 JSON Web Algorithms (JWA).
- Ensures that only valid alg (Algorithm) header parameter values for JWS are used.
- Corrects cases where an invalid algorithm value (e.g., P-256) was referenced, ensuring that only allowed values such as ES256 are specified.